### PR TITLE
Feature/rpc support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - composer self-update
   - composer update
   - php ./tests/server.php &
+  - php ./tests/server-rpc.php &
   - sleep 5
 
 script:

--- a/src/Container/ZeroMQMessageProducerFactory.php
+++ b/src/Container/ZeroMQMessageProducerFactory.php
@@ -25,8 +25,9 @@ final class ZeroMQMessageProducerFactory
 
         $dsn = isset($config['dsn']) ? $config['dsn'] : self::DEFAULT_DSN;
         $persistentId = isset($config['persistent_id']) ? $config['persistent_id'] : self::DEFAULT_PERSISTENT_ID;
+        $rpc = isset($config['rpc']) ? boolval($config['rpc']) : false;
 
-        $socket = $this->makeConnection($persistentId, $dsn);
+        $socket = $this->makeConnection($persistentId, $dsn, $rpc);
         $messageConverter = $this->makeMessageConverter($config);
 
         return new ZeroMQMessageProducer($socket, $messageConverter);
@@ -35,12 +36,14 @@ final class ZeroMQMessageProducerFactory
     /**
      * @param string $persistentId
      * @param string $dsn
+     * @param bool $rpc
      * @return ZeroMQSocket
      */
-    private function makeConnection($persistentId, $dsn)
+    private function makeConnection($persistentId, $dsn, $rpc)
     {
+        $mode = $rpc ? ZMQ::SOCKET_REQ : ZMQ::SOCKET_PUSH;
         $context = new ZMQContext;
-        $socket = new ZMQSocket($context, ZMQ::SOCKET_PUB, $persistentId);
+        $socket = new ZMQSocket($context, $mode, $persistentId);
 
         return new ZeroMQSocket($socket, $dsn);
     }

--- a/src/ZeroMQMessageProducer.php
+++ b/src/ZeroMQMessageProducer.php
@@ -45,9 +45,7 @@ class ZeroMQMessageProducer implements MessageProducer
      */
     public function __invoke(Message $message, Deferred $deferred = null)
     {
-        if ((null !== $deferred) and (! $this->zmqClient->handlesDeferred())) {
-            throw new RuntimeException(__CLASS__ . ' cannot handle query messages which require future responses.');
-        }
+        $this->assertDeferred(null !== $deferred);
 
         $data = $this->arrayFromMessage($message);
 
@@ -56,6 +54,21 @@ class ZeroMQMessageProducer implements MessageProducer
         if ($deferred) {
             $response = $this->zmqClient->receive();
             $deferred->resolve($response);
+        }
+    }
+
+    /**
+     * @param bool $usingDeferred
+     * @throws RuntimeException
+     */
+    private function assertDeferred($usingDeferred)
+    {
+        if ($usingDeferred and (! $this->zmqClient->handlesDeferred())) {
+            throw new RuntimeException(__CLASS__ . ' cannot handle query messages which require future responses.');
+        }
+
+        if ($this->zmqClient->handlesDeferred() and (! $usingDeferred)) {
+            throw new RuntimeException(__CLASS__ . ' cannot handle push and forget messages.');
         }
     }
 

--- a/src/ZeroMQMessageProducer.php
+++ b/src/ZeroMQMessageProducer.php
@@ -45,13 +45,18 @@ class ZeroMQMessageProducer implements MessageProducer
      */
     public function __invoke(Message $message, Deferred $deferred = null)
     {
-        if (null !== $deferred) {
+        if ((null !== $deferred) and (! $this->zmqClient->handlesDeferred())) {
             throw new RuntimeException(__CLASS__ . ' cannot handle query messages which require future responses.');
         }
 
         $data = $this->arrayFromMessage($message);
 
         $this->zmqClient->send(json_encode($data), ZMQ::MODE_DONTWAIT);
+
+        if ($deferred) {
+            $response = $this->zmqClient->receive();
+            $deferred->resolve($response);
+        }
     }
 
     /**

--- a/src/ZeroMQSocket.php
+++ b/src/ZeroMQSocket.php
@@ -47,6 +47,22 @@ class ZeroMQSocket
     /**
      * @return string
      */
+    public function receive()
+    {
+        return $this->socket->recv();
+    }
+
+    /**
+     * @return bool
+     */
+    public function handlesDeferred()
+    {
+        return $this->socket->getSocketType() === \ZMQ::SOCKET_REQ;
+    }
+
+    /**
+     * @return string
+     */
     public function getDsn()
     {
         return $this->dsn;

--- a/tests/Container/ZeroMQMessageProducerFactoryTest.php
+++ b/tests/Container/ZeroMQMessageProducerFactoryTest.php
@@ -84,13 +84,36 @@ class ZeroMQMessageProducerFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function rpc_is_disabled_by_default()
+    {
+        $result = $this->make();
+        $socket = $result->getSocket();
+
+        $this->assertFalse($socket->handlesDeferred());
+    }
+
+    /**
+     * @test
+     */
+    public function rpc_can_be_enabled()
+    {
+        $result = $this->make(null, null, true);
+        $socket = $result->getSocket();
+
+        $this->assertTrue($socket->handlesDeferred());
+    }
+
+    /**
      * @param string $dsn
      * @param string $persistent_id
+     * @param bool $rpc
      * @return ZeroMQMessageProducer
      */
-    private function make($dsn = null, $persistent_id = null)
+    private function make($dsn = null, $persistent_id = null, $rpc = null)
     {
-        $config = compact('dsn', 'persistent_id');
+        $config = compact('dsn', 'persistent_id', 'rpc');
         $this->container->get('config')->willReturn([
             'prooph' => [
                 'producer' => $config,

--- a/tests/ZeroMQMessageProducerTest.php
+++ b/tests/ZeroMQMessageProducerTest.php
@@ -49,8 +49,11 @@ class ZeroMQMessageProducerTest extends \PHPUnit_Framework_TestCase
      * @test
      * @expectedException \RuntimeException
      */
-    public function it_throws_runtime_exception_when_request_deferred()
+    public function it_throws_runtime_exception_when_request_deferred_and_not_using_rpc()
     {
+        $this->zmqClient->handlesDeferred()->willReturn(false)->shouldBeCalled();
+        $this->zmqClient->receive()->shouldNotBeCalled();
+
         $zmqMessageProducer = $this->zmqMessageProducer;
         $doSomething = new DoSomething(['data' => 'test command']);
         $zmqMessageProducer($doSomething, $this->prophesize(\React\Promise\Deferred::class)->reveal());

--- a/tests/ZeroMQMessageProducerTest.php
+++ b/tests/ZeroMQMessageProducerTest.php
@@ -35,6 +35,7 @@ class ZeroMQMessageProducerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_sends_message_as_a_json_encoded_string()
     {
+        $this->zmqClient->handlesDeferred()->willReturn(false);
         $zmqMessageProducer = $this->zmqMessageProducer;
         $doSomething = new DoSomething(['data' => 'test command']);
 
@@ -58,6 +59,19 @@ class ZeroMQMessageProducerTest extends \PHPUnit_Framework_TestCase
         $zmqMessageProducer = $this->zmqMessageProducer;
         $doSomething = new DoSomething(['data' => 'test command']);
         $zmqMessageProducer($doSomething, $this->prophesize(Deferred::class)->reveal());
+    }
+
+    /**
+     * @test
+     * @expectedException \Prooph\ServiceBus\Exception\RuntimeException
+     */
+    public function it_throws_runtime_exception_when_request_is_not_deferred_and_using_rpc()
+    {
+        $this->zmqClient->handlesDeferred()->willReturn(true)->shouldBeCalled();
+
+        $zmqMessageProducer = $this->zmqMessageProducer;
+        $doSomething = new DoSomething(['data' => 'test command']);
+        $zmqMessageProducer($doSomething);
     }
 
     /**

--- a/tests/ZeroMQMessageProducerTest.php
+++ b/tests/ZeroMQMessageProducerTest.php
@@ -47,7 +47,7 @@ class ZeroMQMessageProducerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
+     * @expectedException \Prooph\ServiceBus\Exception\RuntimeException
      */
     public function it_throws_runtime_exception_when_request_deferred_and_not_using_rpc()
     {

--- a/tests/ZeroMQSocketTest.php
+++ b/tests/ZeroMQSocketTest.php
@@ -6,43 +6,38 @@ use Prooph\ServiceBus\Message\ZeroMQ\ZeroMQSocket;
 
 class ZeroMQSocketTest extends \PHPUnit_Framework_TestCase
 {
-    /** @var ZeroMQSocket */
-    private $zmqClient;
-
-    /** @var \ZMQSocket */
-    private $socket;
-
-    /** @var string */
-    private $dsn = 'tcp://localhost:5555';
-
-    /** @var string */
-    private $storage;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->storage = __DIR__ . '/zmq-out.log';
-        $this->socket = new \ZMQSocket(new \ZMQContext, \ZMQ::SOCKET_PUSH);
-        $this->zmqClient = new ZeroMQSocket($this->socket, $this->dsn);
-    }
-
-    public function tearDown()
-    {
-        $this->socket->disconnect($this->dsn);
-    }
-
     /**
      * @test
      */
     public function it_sends_message()
     {
-        @unlink($this->storage);
-        $this->zmqClient->send($message = 'testing-123');
+        $socket = new \ZMQSocket(new \ZMQContext, \ZMQ::SOCKET_PUSH);
+        $storage = __DIR__ . '/zmq-out.log';
+        $zmqClient = new ZeroMQSocket($socket, 'tcp://localhost:5555');
+
+        @unlink($storage);
+        $zmqClient->send($message = 'testing-123');
 
         sleep(5);
-        $contents = trim(file_get_contents($this->storage));
+        $contents = trim(file_get_contents($storage));
 
         $this->assertEquals($message, $contents);
+
+        $socket->disconnect('tcp://localhost:5555');
+    }
+
+    /**
+     * @test
+     */
+    public function it_sends_message_and_gets_response()
+    {
+        $socket = new \ZMQSocket(new \ZMQContext, \ZMQ::SOCKET_REQ);
+        $zmqClient = new ZeroMQSocket($socket, 'tcp://localhost:5556');
+
+        $zmqClient->send($message = 'testing-123');
+
+        $this->assertEquals($message, $zmqClient->receive());
+
+        $socket->disconnect('tcp://localhost:5556');
     }
 }

--- a/tests/server-rpc.php
+++ b/tests/server-rpc.php
@@ -1,0 +1,15 @@
+<?php
+
+if (! extension_loaded('zmq')) {
+    throw new RuntimeException('Requires `ext-zmq` extension to run server.');
+}
+
+$context = new ZMQContext;
+$socket = new ZMQSocket($context, ZMQ::SOCKET_REP);
+$socket->bind('tcp://127.0.0.1:5556');
+
+echo "ZMQ Stub Server Started.";
+
+while ($message = $socket->recv()) {
+    $socket->send($message);
+}

--- a/tests/server.php
+++ b/tests/server.php
@@ -6,9 +6,9 @@ if (! extension_loaded('zmq')) {
 
 $context = new ZMQContext;
 $socket = new ZMQSocket($context, ZMQ::SOCKET_PULL);
-$socket->bind("tcp://127.0.0.1:5555");
+$socket->bind('tcp://127.0.0.1:5555');
 
-echo "ZMQ Stub Server Started.";
+echo 'ZMQ Stub Server Started.';
 
 while ($message = $socket->recv()) {
     file_put_contents(__DIR__ . '/zmq-out.log', $message . PHP_EOL, FILE_APPEND);


### PR DESCRIPTION
#### What's this PR do?

This allows the use of deferred using the ZeroMQ producer. This would be that another producer instance is required in order to have a command bus and a query bus as ZMQ will only allow a single bus type without complexity.
#### Where should the reviewer start?

You will need a ZeroMQ server and a PHP installation with `ext-zmq`. 
#### How should this be manually tested?
1. Setup the ZeroMQ server.
2. Add a consumer to the ZMQ server.
3. Set the PSB adapter to use `Prooph\ServiceBus\Message\ZeroMQ\ZeroMQMessageProducer`
4. Configure the ZMQ adapter, by adding the DSN required and setting rpc to true. (more doc later)
5. Dispatch a query to the PSB with a deferred.
6. Check that the consumer gets the query and responds.
7. Check the producer receives that response.
#### Any background context you want to provide?

There was a requirement for RPC on the ZMQ producer.
#### Definition of Done:
- [x] Tests are all passing.
- [x] Been tested with a live ZMQ server (check `tests/server-rpc.php`).
