### PR TITLE
Optional config and prefixed producer config key

### DIFF
--- a/src/Container/ZeroMQMessageProducerFactory.php
+++ b/src/Container/ZeroMQMessageProducerFactory.php
@@ -10,7 +10,7 @@ use Interop\Container\ContainerInterface;
 use Prooph\Common\Messaging\NoOpMessageConverter;
 use Prooph\ServiceBus\Message\ZeroMQ\ZeroMQMessageProducer;
 
-final class ZeroMQMessageProducerFactory
+class ZeroMQMessageProducerFactory
 {
     const DEFAULT_DSN = 'tcp://127.0.0.1:5555';
     const DEFAULT_PERSISTENT_ID = 'prooph';
@@ -21,7 +21,7 @@ final class ZeroMQMessageProducerFactory
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('config')['prooph']['producer'];
+        $config = $this->getConfigFromContainer($container);
 
         $dsn = isset($config['dsn']) ? $config['dsn'] : self::DEFAULT_DSN;
         $persistentId = isset($config['persistent_id']) ? $config['persistent_id'] : self::DEFAULT_PERSISTENT_ID;
@@ -31,6 +31,18 @@ final class ZeroMQMessageProducerFactory
         $messageConverter = $this->makeMessageConverter($config);
 
         return new ZeroMQMessageProducer($socket, $messageConverter);
+    }
+
+    /**
+     * Override this method in a custom factory to access a custom config path
+     *
+     * @param ContainerInterface $container
+     * @return array
+     */
+    protected function getConfigFromContainer(ContainerInterface $container)
+    {
+        return isset($container->get('config')['prooph']['zeromq_producer'])
+            ? $container->get('config')['prooph']['zeromq_producer'] : [] ;
     }
 
     /**

--- a/tests/Container/ZeroMQMessageProducerFactoryTest.php
+++ b/tests/Container/ZeroMQMessageProducerFactoryTest.php
@@ -24,7 +24,7 @@ class ZeroMQMessageProducerFactoryTest extends \PHPUnit_Framework_TestCase
     public function it_will_get_configuration()
     {
         $this->container->get('config')->willReturn([
-            'prooph' => ['producer' => []],
+            'prooph' => ['zeromq_producer' => []],
         ])->shouldBeCalled();
 
         $factory = new ZeroMQMessageProducerFactory;
@@ -106,6 +106,19 @@ class ZeroMQMessageProducerFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    function it_does_not_require_a_configuration()
+    {
+        $this->container->get('config')->willReturn([])->shouldBeCalled();
+
+        $factory = new ZeroMQMessageProducerFactory;
+        $producer = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(ZeroMQMessageProducer::class, $producer);
+    }
+
+    /**
      * @param string $dsn
      * @param string $persistent_id
      * @param bool $rpc
@@ -116,7 +129,7 @@ class ZeroMQMessageProducerFactoryTest extends \PHPUnit_Framework_TestCase
         $config = compact('dsn', 'persistent_id', 'rpc');
         $this->container->get('config')->willReturn([
             'prooph' => [
-                'producer' => $config,
+                'zeromq_producer' => $config,
             ],
         ])->shouldBeCalled();
 

--- a/tests/Container/ZeroMQMessageProducerFactoryTest.php
+++ b/tests/Container/ZeroMQMessageProducerFactoryTest.php
@@ -108,7 +108,7 @@ class ZeroMQMessageProducerFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    function it_does_not_require_a_configuration()
+    public function it_does_not_require_a_configuration()
     {
         $this->container->get('config')->willReturn([])->shouldBeCalled();
 


### PR DESCRIPTION
This PR provides some improvements for the factory:
- application config is optional as the producer has smart defaults
- moved config location into a protected method and removed the `final` keyword from the factory so that a userland implementation can extend the factory and use for example [interop-config](https://github.com/sandrokeil/interop-config) to load config from a custom path
- changed the config package name from `producer` to `zeromq_producer` as we have various producers available for prooph/service-bus which might be used in parallel
